### PR TITLE
fix(infracost-backend): add a larger body limit for requests

### DIFF
--- a/plugins/infracost-backend/src/service/router.ts
+++ b/plugins/infracost-backend/src/service/router.ts
@@ -28,6 +28,7 @@ export async function createRouter(
   router.use(express.json());
   router.use(
     express.urlencoded({
+      limit: '5mb',
       extended: true,
     }),
   );


### PR DESCRIPTION
I have noticed that the current backend will crash if the `base.json` file that is posted to the backend is bigger than the express default (which is 100kb). 
With bigger infrastructure repositories, the base cost `json` file that Infracost generates can become quite large so this is a bug that will most likely start to affect teams using this plugin in larger and more complex environments